### PR TITLE
support more bip32 params for chains

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ssp-wallet",
   "description": "Secure. Simple. Powerful.",
   "private": true,
-  "version": "1.2.1",
+  "version": "1.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.1",
+  "version": "1.2.2",
   "manifest_version": 3,
   "name": "SSP Wallet",
   "short_name": "SSP",

--- a/src/lib/wallet.ts
+++ b/src/lib/wallet.ts
@@ -110,8 +110,18 @@ export function generateMultisigAddress(
   const network = utxolib.networks[libID];
   const bipParams = blockchains[chain].bip32;
   const type = blockchains[chain].scriptType;
-  const externalChain1 = HDKey.fromExtendedKey(xpub1, bipParams);
-  const externalChain2 = HDKey.fromExtendedKey(xpub2, bipParams);
+  const networkBipParams = utxolib.networks[libID].bip32;
+  let externalChain1, externalChain2;
+  try {
+    externalChain1 = HDKey.fromExtendedKey(xpub1, bipParams);
+  } catch (e) {
+    externalChain1 = HDKey.fromExtendedKey(xpub1, networkBipParams);
+  }
+  try {
+    externalChain2 = HDKey.fromExtendedKey(xpub2, bipParams);
+  } catch (e) {
+    externalChain2 = HDKey.fromExtendedKey(xpub2, networkBipParams);
+  }
 
   const externalAddress1 = externalChain1
     .deriveChild(typeIndex)
@@ -195,7 +205,17 @@ export function generateAddressKeypair(
 ): keyPair {
   const libID = getLibId(chain);
   const bipParams = blockchains[chain].bip32;
-  const externalChain = HDKey.fromExtendedKey(xpriv, bipParams);
+  const networkBipParams = utxolib.networks[libID].bip32;
+  let externalChain;
+  let network = utxolib.networks[libID];
+  try {
+    externalChain = HDKey.fromExtendedKey(xpriv, bipParams);
+    network = Object.assign({}, network, {
+      bip32: bipParams,
+    });
+  } catch (e) {
+    externalChain = HDKey.fromExtendedKey(xpriv, networkBipParams);
+  }
 
   const externalAddress = externalChain
     .deriveChild(typeIndex)
@@ -203,7 +223,7 @@ export function generateAddressKeypair(
 
   const derivedExternalAddress: minHDKey = utxolib.HDNode.fromBase58(
     externalAddress.toJSON().xpriv,
-    utxolib.networks[libID],
+    network,
   );
 
   const privateKeyWIF: string = derivedExternalAddress.keyPair.toWIF();
@@ -225,7 +245,13 @@ export function generateInternalIdentityAddress(
 
   const libID = getLibId(chain);
   const bipParams = blockchains[chain].bip32;
-  const externalChain = HDKey.fromExtendedKey(xpub, bipParams);
+  const networkBipParams = utxolib.networks[libID].bip32;
+  let externalChain;
+  try {
+    externalChain = HDKey.fromExtendedKey(xpub, bipParams);
+  } catch (e) {
+    externalChain = HDKey.fromExtendedKey(xpub, networkBipParams);
+  }
 
   const externalAddress = externalChain
     .deriveChild(typeIndex)
@@ -250,7 +276,13 @@ export function generateExternalIdentityAddress(xpub: string): string {
 
   const libID = getLibId(chain);
   const bipParams = blockchains[chain].bip32;
-  const externalChain = HDKey.fromExtendedKey(xpub, bipParams);
+  const networkBipParams = utxolib.networks[libID].bip32;
+  let externalChain;
+  try {
+    externalChain = HDKey.fromExtendedKey(xpub, bipParams);
+  } catch (e) {
+    externalChain = HDKey.fromExtendedKey(xpub, networkBipParams);
+  }
 
   const externalAddress = externalChain
     .deriveChild(typeIndex)
@@ -276,7 +308,17 @@ export function generateNodeIdentityKeypair(
 ): keyPair {
   const libID = getLibId(chain);
   const bipParams = blockchains[chain].bip32;
-  const externalChain = HDKey.fromExtendedKey(xpriv, bipParams);
+  const networkBipParams = utxolib.networks[libID].bip32;
+  let externalChain;
+  let network = utxolib.networks[libID];
+  try {
+    externalChain = HDKey.fromExtendedKey(xpriv, bipParams);
+    network = Object.assign({}, network, {
+      bip32: bipParams,
+    });
+  } catch (e) {
+    externalChain = HDKey.fromExtendedKey(xpriv, networkBipParams);
+  }
 
   const externalAddress = externalChain
     .deriveChild(typeIndex)
@@ -284,7 +326,7 @@ export function generateNodeIdentityKeypair(
 
   const derivedExternalAddress: minHDKey = utxolib.HDNode.fromBase58(
     externalAddress.toJSON().xpriv,
-    utxolib.networks[libID],
+    network,
   );
 
   const privateKeyWIF: string = derivedExternalAddress.keyPair.toWIF();
@@ -326,7 +368,10 @@ export function generateExternalIdentityKeypair( // in memory we store just addr
 }
 
 // from private key in wif format, get private key in hex format
-export function wifToPrivateKey(privateKey: string, chain: keyof cryptos): string {
+export function wifToPrivateKey(
+  privateKey: string,
+  chain: keyof cryptos,
+): string {
   const libID = getLibId(chain);
   const network = utxolib.networks[libID];
   const keyPair = utxolib.ECPair.fromWIF(privateKey, network);

--- a/src/storage/blockchains.ts
+++ b/src/storage/blockchains.ts
@@ -139,8 +139,8 @@ const btc = {
   wif: '80',
   logo: btcLogo,
   bip32: {
-    public: 0x0488b21e,
-    private: 0x0488ade4,
+    public: 0x02aa7ed3,
+    private: 0x02aa7a99,
   },
   backend: 'blockbook',
   bech32: 'bc1',
@@ -194,8 +194,8 @@ const btcTestnet = {
   wif: 'ef',
   logo: btcTestnetLogo,
   bip32: {
-    public: 0x043587cf,
-    private: 0x04358394,
+    public: 0x02575483,
+    private: 0x02575048,
   },
   backend: 'blockbook',
   bech32: 'tb1',
@@ -222,8 +222,8 @@ const btcSignet = {
   wif: 'ef',
   logo: btcSignetLogo,
   bip32: {
-    public: 0x043587cf,
-    private: 0x04358394,
+    public: 0x02575483,
+    private: 0x02575048,
   },
   backend: 'blockbook',
   bech32: 'tb1',

--- a/src/utxolib.d.ts
+++ b/src/utxolib.d.ts
@@ -40,9 +40,20 @@ declare module '@runonflux/utxo-lib' {
       outs: output[];
     };
   }
-  type networks = Record<string, object>;
+  interface network {
+    messagePrefix: string;
+    bech32: string;
+    bip32: {
+      public: number;
+      private: number;
+    };
+    pubKeyHash: string;
+    scriptHash: string;
+    wif: string;
+  }
+  type networks = Record<string, network>;
   let address: {
-    fromOutputScript: (scriptPubKey: Uint8Array, network: object) => string;
+    fromOutputScript: (scriptPubKey: Uint8Array, network: network) => string;
   };
   let script: {
     multisig: {
@@ -72,43 +83,43 @@ declare module '@runonflux/utxo-lib' {
     sha256: (witnessScript: Uint8Array) => Buffer;
   };
   let HDNode: {
-    fromBase58: (xpubxpriv: string, network: object) => minHDKey;
+    fromBase58: (xpubxpriv: string, network: network) => minHDKey;
   };
   interface TX {
     virtualSize(): number;
     ins: inInput[];
   }
   let Transaction: {
-    fromHex: (txhex: string, network: object) => TX;
+    fromHex: (txhex: string, network: network) => TX;
     SIGHASH_ALL: number;
   };
   // Other methods/properties...
   // Replace 'any' with the appropriate type // Define the constructor signature and any other methods/properties
   type TransactionBuilder = new (
-    network: object,
+    network: network,
     fee: string,
   ) => {
     setVersion: (version: number) => void;
     setVersionGroupId: (versionGroupId: number) => void;
     addInput: (txid: string, vout: number, sequence?: number) => void;
     addOutput: (address: string, satoshis: number) => void;
-    fromTransaction: (tx: TX, network: object) => txBuilder;
+    fromTransaction: (tx: TX, network: network) => txBuilder;
     buildIncomplete: () => builtTx;
   };
   let TransactionBuilder: {
-    fromTransaction: (tx: TX, network: object) => txBuilder;
+    fromTransaction: (tx: TX, network: network) => txBuilder;
   } & TransactionBuilder;
   let ECPair: {
     fromWIF: (
       privateKey: string,
-      network: object,
+      network: network,
     ) => {
       sign: (hash: Buffer) => Buffer;
       getPrivateKeyBuffer: () => Buffer;
     };
     fromPublicKeyBuffer: (
       publicKeyBuffer: Buffer,
-      network?: object,
+      network?: network,
     ) => {
       getAddress: () => string;
     };


### PR DESCRIPTION
As per 
https://github.com/satoshilabs/slips/blob/master/slip-0132.md
and
https://electrum.readthedocs.io/en/latest/xpub_version_bytes.html
SSP will now use proper version bytes of bip32 for extended public keys. This affects bitcoin networks only which is the only network specifying it for segwit properly. Other networks will follow P2SH bip32 specifications unless they specify. 
SSP will always support BOTH version bytes. Defaulting to registered slip value with a fallback to default p2sh value of the network.
Already synced chains of ssp will display the synced version of xpub. Newly synced chains will display new verisons. Restoration will force new version of version bytes.
For compatibility reasons both ssp wallet and ssp key need to be updated in case of syncing some chain. Compatibility is kept for existing wallets.
Both bip32 versions bytes generate the same keypairs, addresses, only human readable version of extended keys is affected.