### PR TITLE
fix: handle EVM txs without a receiver in token/external scans

### DIFF
--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -213,8 +213,11 @@ export function processTransactionTokenScan(
   tx: etherscan_token_tx,
   address: string,
 ): transaction {
+  // Contract creations (and some explorer variants) omit `to` — fall back to
+  // the created contract address so the transfer correctly shows as outgoing.
+  const receiver = tx.to || tx.contractAddress || '';
   let amount = tx.value;
-  if (address.toLowerCase() !== tx.to.toLowerCase()) {
+  if (address.toLowerCase() !== receiver.toLowerCase()) {
     amount = '-' + amount;
   }
   const { gasUsed, gasPrice } = tx;
@@ -229,7 +232,7 @@ export function processTransactionTokenScan(
     timestamp: Number(tx.timeStamp) * 1000,
     amount,
     message: '',
-    receiver: tx.to,
+    receiver,
     isError: false,
     decimals: Number(tx.tokenDecimal),
     tokenSymbol: tx.tokenSymbol,
@@ -332,8 +335,11 @@ export function processTransactionExternalScan(
   tx: etherscan_external_tx,
   address: string,
 ): transaction {
+  // Contract creations (and some explorer variants) omit `to` — an absent
+  // receiver can never equal our address, so the value shows as outgoing.
+  const receiver = tx.to || '';
   let amount = tx.value;
-  if (address.toLowerCase() !== tx.to.toLowerCase()) {
+  if (address.toLowerCase() !== receiver.toLowerCase()) {
     amount = '-' + amount;
   }
   const { gasUsed, gasPrice } = tx;
@@ -348,7 +354,7 @@ export function processTransactionExternalScan(
     timestamp: Number(tx.timeStamp) * 1000,
     amount,
     message: '',
-    receiver: tx.to,
+    receiver,
     isError: !!tx.isError,
   };
   return tran;

--- a/tests/lib/transactions.spec.ts
+++ b/tests/lib/transactions.spec.ts
@@ -8,6 +8,7 @@ import {
   processTransactionsInternalScan,
   processTransactionExternalScan,
   processTransactionsExternalScan,
+  processTransactionTokenScan,
   fetchAddressTransactions,
   fetchAllAddressTransactions,
   decodeTransactionForApproval,
@@ -156,6 +157,43 @@ describe('Transactions Lib', () => {
       expect(res.message).toBe('');
       expect(res.isError).toBe(false);
       expect(res.receiver).toBe('0x8092557902BA4dE6f83a7E27e14b8F0bF8ADFeA1');
+    });
+
+    it('handles contract-creation txs without `to` in processTransactionExternalScan', () => {
+      const res = processTransactionExternalScan(
+        {
+          hash: '0xee2d88632242c178707e6ed3577548041e0efa761035a84151c59364e8ba76f3',
+          blockNumber: 20597003,
+          timeStamp: 1724488730,
+          value: 1000,
+          // contract creation: no `to` field at all
+        },
+        '0xE6F30E1B28C67d787Bf8Bd21bA8E9756707E4713',
+        'ETH',
+      );
+      expect(res).toBeDefined();
+      expect(res.receiver).toBe('');
+      // absent receiver can never be us → value shows as outgoing
+      expect(res.amount).toBe('-1000');
+    });
+
+    it('handles token txs without `to` in processTransactionTokenScan', () => {
+      const res = processTransactionTokenScan(
+        {
+          hash: '0xee2d88632242c178707e6ed3577548041e0efa761035a84151c59364e8ba76f3',
+          blockNumber: 20597003,
+          timeStamp: 1724488730,
+          value: 5,
+          tokenDecimal: 18,
+          tokenSymbol: 'TST',
+          contractAddress: '0x8092557902BA4dE6f83a7E27e14b8F0bF8ADFeA1',
+          // no `to` field — falls back to the created contract address
+        },
+        '0xE6F30E1B28C67d787Bf8Bd21bA8E9756707E4713',
+      );
+      expect(res).toBeDefined();
+      expect(res.receiver).toBe('0x8092557902BA4dE6f83a7E27e14b8F0bF8ADFeA1');
+      expect(res.amount).toBe('-5');
     });
 
     it('should return processTransactionsExternalScan data when value is valid', () => {


### PR DESCRIPTION
Contract-creation transactions omit `to`; the token/external scan processors crashed on `tx.to.toLowerCase()`. Falls back to the created contract address (token scan) or an empty receiver, with regression tests. This was the last failing test on master CI after the FDM reroute.