### PR TITLE
fix: tutorial sync-step stall + switcher horizontal overflow

### DIFF
--- a/src/components/Tutorial/TutorialProvider.tsx
+++ b/src/components/Tutorial/TutorialProvider.tsx
@@ -3,6 +3,7 @@ import React, {
   useContext,
   useState,
   useEffect,
+  useMemo,
   ReactNode,
 } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
@@ -605,11 +606,21 @@ export const TutorialProvider: React.FC<TutorialProviderProps> = ({
     }
   }, [pendingTutorialType]);
 
-  // Auto-advance from ethereum-sync-waiting (step 5) to ethereum-tokens (step 6)
+  // Auto-advance from ethereum-sync-waiting to ethereum-tokens. Resolve the
+  // step by ID — a hardcoded index silently broke once when a step was added
+  // before it, leaving every user stuck on "continues automatically".
+  const syncWaitingStepIndex = useMemo(() => {
+    const tutorialSteps = getTutorialSteps(t as (key: string) => string);
+    const steps =
+      tutorialSteps[tutorialState.tutorialType] || tutorialSteps.onboarding;
+    return steps.findIndex((step) => step.id === 'ethereum-sync-waiting');
+  }, [t, tutorialState.tutorialType]);
+
   useEffect(() => {
     if (
       tutorialState.isActive &&
-      tutorialState.currentStep === 4 && // Step 5 (ethereum-sync-waiting) is index 4
+      syncWaitingStepIndex !== -1 &&
+      tutorialState.currentStep === syncWaitingStepIndex &&
       activeChain === 'eth' &&
       ethXpubKey // Ensure Ethereum SSP Key is actually synced
     ) {
@@ -657,6 +668,7 @@ export const TutorialProvider: React.FC<TutorialProviderProps> = ({
   }, [
     tutorialState.isActive,
     tutorialState.currentStep,
+    syncWaitingStepIndex,
     activeChain,
     ethXpubKey,
     nextStep,

--- a/src/components/WalletSwitcher/WalletSwitcher.css
+++ b/src/components/WalletSwitcher/WalletSwitcher.css
@@ -19,6 +19,9 @@
   align-items: center;
   gap: 12px;
   width: 100%;
+  /* no global border-box reset in this app — without this, 100% + padding
+     overflows the drawer body and makes the whole sheet scroll sideways */
+  box-sizing: border-box;
   padding: 8px 10px;
   border: none;
   border-radius: 12px;
@@ -242,6 +245,7 @@
   align-items: center;
   gap: 12px;
   width: 100%;
+  box-sizing: border-box; /* see .switcher-wallet */
   padding: 8px 10px;
   border: none;
   border-radius: 12px;
@@ -307,4 +311,10 @@
 /* Hide WalletName's inline editor inside the compact switcher rows */
 .switcher-wallet-name .ant-input {
   display: none;
+}
+
+/* The sheet must never scroll sideways — vertical only. Guards against any
+   future stray few-px overflow re-introducing the horizontal scrollbar. */
+.wallet-switcher .ant-drawer-body {
+  overflow-x: hidden;
 }


### PR DESCRIPTION
Two user-facing fixes, both verified against the built extension in popup and side-panel modes:

- **Tutorial**: the Ethereum sync step auto-advance was pinned to a stale step index (broken since backup-health was inserted) — every user stalled at 6/21. Now resolved by step ID; full 21-step tour completes in both display modes.
- **Wallet switcher**: rows overflowed the drawer by 20px (width:100% + padding without border-box), making the sheet horizontally scrollable. Fixed with border-box + an overflow-x guard.