### PR TITLE
feat: Portfolio landing, zero-balance receive CTA, testnet visibility toggle

### DIFF
--- a/scripts/upgrade-in-place.mjs
+++ b/scripts/upgrade-in-place.mjs
@@ -220,6 +220,24 @@ async function unlockWithPassword(page) {
 }
 
 async function readHomeAddress(page) {
+  // New builds land on Portfolio (chain-neutral landing) when no lastTab is
+  // stored — the address container lives on Home, so switch tabs if needed.
+  // Old builds have no tab bar button; the wait just falls through.
+  const addressVisible = await page
+    .locator('[data-tutorial="wallet-address"]')
+    .isVisible()
+    .catch(() => false);
+  if (!addressVisible) {
+    const homeTab = page.locator('button[data-tutorial="tab-home"]');
+    if (
+      await homeTab
+        .waitFor({ timeout: 5_000 })
+        .then(() => true)
+        .catch(() => false)
+    ) {
+      await homeTab.click().catch(() => {});
+    }
+  }
   const container = page.locator('[data-tutorial="wallet-address"]');
   await container.waitFor({ timeout: NAV_TIMEOUT });
   const text = (await container.innerText()).trim();

--- a/src/blockchains.d.ts
+++ b/src/blockchains.d.ts
@@ -57,4 +57,6 @@ declare module '@storage/blockchains' {
   }
   type blockchains = Record<string, Blockchain>;
   let blockchains: blockchains;
+  // SLIP-44 coin type 1 — the universal testnet marker
+  let isTestnetChain: (chain: string) => boolean;
 }

--- a/src/components/Key/Key.tsx
+++ b/src/components/Key/Key.tsx
@@ -6,7 +6,7 @@ import {
   SendHorizontal as SendHorizontalIcon,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { blockchains } from '@storage/blockchains';
+import { blockchains, isTestnetChain } from '@storage/blockchains';
 import localForage from 'localforage';
 import {
   App,
@@ -1159,13 +1159,16 @@ function Key(props: {
     batch.phase !== 'preparing' && batch.phase !== 'syncing';
 
   // Chains offered for extra activation: everything except the identity
-  // chain, the chain being activated, and chains that are already synced.
+  // chain, the chain being activated, chains that are already synced, and —
+  // unless enabled in Settings — testnets.
   // "Already synced" must consult secure storage (2-xpub-48-* present), not
   // just redux — the store only hydrates a chain's key xpub once the chain
   // has been switched to this session.
+  const showTestnets = Boolean(sspConfig().showTestnets);
   const offeredChains = (Object.keys(blockchains) as (keyof cryptos)[]).filter(
     (chain) => {
       if (chain === identityChain || chain === activeChain) return false;
+      if (!showTestnets && isTestnetChain(chain)) return false;
       if (store.getState()[chain]?.xpubKey) return false;
       return !hasStoredKeyXpub(chain);
     },

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { Tooltip } from 'antd';
 import {
   ArrowDown as ArrowDownIcon,
@@ -23,7 +23,13 @@ import './Navigation.css';
 function Navigation() {
   const { t } = useTranslation(['home']);
   const navigate = useNavigate();
-  const [openReceive, setOpenReceive] = useState(false);
+  const location = useLocation();
+  // Portfolio's zero-balance "Receive your first crypto" CTA lands on Home
+  // with this router state — open the Receive sheet right away (captured once
+  // at mount, same pattern as the shell's `imported` flag).
+  const [openReceive, setOpenReceive] = useState(() =>
+    Boolean((location.state as { openReceive?: boolean } | null)?.openReceive),
+  );
   const [openBuyCryptoDialog, setOpenBuyCryptoDialog] = useState(false);
   const receiveAction = (status: boolean) => {
     setOpenReceive(status);

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -21,6 +21,7 @@ import {
   Cloud as CloudIcon,
   Coins as CoinsIcon,
   Compass as CompassIcon,
+  FlaskConical as FlaskConicalIcon,
   HardDrive as HardDriveIcon,
   Hash as HashIcon,
   KeyRound as KeyRoundIcon,
@@ -196,6 +197,9 @@ function Settings() {
   const [sspConfigRelay, setSspConfigRelay] = useState(sspConfig().relay);
   const SSPFC = sspConfig().fiatCurrency;
   const [sspFiatCurrency, setSspFiatCurrency] = useState(SSPFC);
+  const [showTestnets, setShowTestnets] = useState(
+    Boolean(sspConfig().showTestnets),
+  );
   const [nodeConfig, setNodeConfig] = useState(NC);
   const [apiConfig, setApiConfig] = useState(API);
   const [explorerConfig, setExplorerConfig] = useState(EXPLORER);
@@ -469,6 +473,24 @@ function Settings() {
     } catch (error) {
       console.log(error);
       setSspFiatCurrency(previous); // never leave the row showing an unsaved value
+      displayMessage('error', t('home:settings.err_saving_conf'));
+    }
+  };
+
+  /**
+   * Testnet visibility applies IMMEDIATELY, like the other Preferences rows —
+   * chain lists (Portfolio, wallet switcher) read `sspConfig().showTestnets`
+   * on their next render.
+   */
+  const applyShowTestnets = async (checked: boolean) => {
+    const previous = showTestnets;
+    setShowTestnets(checked);
+    try {
+      await updateUserPreferences({ showTestnets: checked });
+      loadSSPConfig();
+    } catch (error) {
+      console.log(error);
+      setShowTestnets(previous); // never leave the row showing an unsaved value
       displayMessage('error', t('home:settings.err_saving_conf'));
     }
   };
@@ -1210,6 +1232,21 @@ function Settings() {
               { value: 'light', label: t('home:settings.theme_light') },
               { value: 'dark', label: t('home:settings.theme_dark') },
             ]}
+          />
+        </Row>
+        <Row
+          icon={<FlaskConicalIcon />}
+          label={t('home:settings.show_testnets', 'Show testnet networks')}
+        >
+          <Switch
+            checked={showTestnets}
+            aria-label={t(
+              'home:settings.show_testnets',
+              'Show testnet networks',
+            )}
+            onChange={(checked) => {
+              void applyShowTestnets(checked);
+            }}
           />
         </Row>
       </Section>

--- a/src/components/WalletSwitcher/WalletSwitcher.tsx
+++ b/src/components/WalletSwitcher/WalletSwitcher.tsx
@@ -29,7 +29,7 @@ import {
   setActivatedTokens,
   setImportedTokens,
 } from '../../store';
-import { blockchains, Token } from '@storage/blockchains';
+import { blockchains, isTestnetChain, Token } from '@storage/blockchains';
 import { generateMultisigAddress } from '../../lib/wallet.ts';
 import { switchToChain } from '../../lib/chainSwitching';
 import { formatCrypto, formatFiatWithSymbol } from '../../lib/currency';
@@ -130,7 +130,16 @@ function WalletSwitcher({ open, openAction, stayOnRoute }: Props) {
     });
   }, [walletIds, query, walletNamesForChain, wallets, activeChain]);
 
-  const chainKeys = Object.keys(blockchains) as (keyof cryptos)[];
+  // Testnets stay hidden unless enabled in Settings — except the chain the
+  // user is currently ON, which must always be visible (and returnable-to).
+  const showTestnets = Boolean(sspConfig().showTestnets);
+  const chainKeys = useMemo(
+    () =>
+      (Object.keys(blockchains) as (keyof cryptos)[]).filter(
+        (c) => showTestnets || c === activeChain || !isTestnetChain(c),
+      ),
+    [showTestnets, activeChain],
+  );
   const filteredChains = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return chainKeys;

--- a/src/lib/portfolio.ts
+++ b/src/lib/portfolio.ts
@@ -3,6 +3,7 @@ import localForage from 'localforage';
 import { blockchains } from '@storage/blockchains';
 import type { Token } from '@storage/blockchains';
 import { hasStoredKeyXpub } from './chainSync';
+import { store } from '../store';
 import { fetchAddressBalance, fetchAddressTokenBalances } from './balances';
 import type {
   cryptos,
@@ -103,6 +104,17 @@ async function discoverChains(): Promise<
         `wallets-${chain}`,
         {},
       );
+      // The shell writes a freshly generated address to redux synchronously
+      // but to localForage asynchronously — right after onboarding (which now
+      // lands directly on Portfolio) the durable map can lag a beat behind.
+      // Merge the in-memory map so a just-paired chain is never misread as
+      // "not yet activated".
+      const memWallets = store.getState()[chain]?.wallets ?? {};
+      for (const [id, wal] of Object.entries(memWallets)) {
+        if (wal?.address && !wallets[id]) {
+          wallets[id] = wal.address;
+        }
+      }
       const walletInUse = await safeGetItem<string>(
         `walletInUse-${chain}`,
         '0-0',

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -579,7 +579,7 @@ function Login() {
               );
             }
             // Open where the user left off (append-only navPrefs; defaults to
-            // Home for fresh profiles — keeps the upgrade-in-place gate green).
+            // Portfolio — the chain-neutral landing view — for fresh profiles).
             const navState = cameFromImport
               ? { state: { imported: true } }
               : undefined;
@@ -587,7 +587,7 @@ function Login() {
               const lastTab = await getLastTab();
               navigate(tabToPath(lastTab), navState);
             } catch {
-              navigate('/home', navState);
+              navigate('/portfolio', navState);
             }
           } else {
             failUnlock(t('login:err_lx', { code: 'L2' }));

--- a/src/pages/Portfolio/Portfolio.css
+++ b/src/pages/Portfolio/Portfolio.css
@@ -256,11 +256,76 @@
   white-space: nowrap;
 }
 
+/* Zero-balance funding CTA — amber-tinted tile in the Home action row's
+   design language, shown only while every active chain holds nothing. */
+.portfolio-empty-cta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  box-sizing: border-box;
+  margin: 14px 0 2px;
+  padding: 12px 14px;
+  border: none;
+  border-radius: 12px;
+  background: rgba(245, 158, 11, 0.12);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s ease;
+}
+
+.portfolio-empty-cta:hover {
+  background: rgba(245, 158, 11, 0.2);
+}
+
+.portfolio-empty-cta:focus-visible {
+  outline: 2px solid var(--ssp-focus);
+  outline-offset: 2px;
+}
+
+.portfolio-empty-cta-icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  color: #b45309; /* amber-700 — ≥4.5:1 on the tinted light surface */
+}
+
+:root[data-theme='dark'] .portfolio-empty-cta {
+  background: rgba(245, 158, 11, 0.14);
+}
+
+:root[data-theme='dark'] .portfolio-empty-cta:hover {
+  background: rgba(245, 158, 11, 0.22);
+}
+
+:root[data-theme='dark'] .portfolio-empty-cta-icon {
+  color: #fbbf24; /* brand amber-400 on dark */
+}
+
+.portfolio-empty-cta-meta {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.35;
+}
+
+.portfolio-empty-cta-title {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.portfolio-empty-cta-sub {
+  font-size: 12px;
+  opacity: 0.65;
+}
+
 /* Honour the OS reduce-motion preference, like the rest of the app's
  * stylesheets. Scoped to this file's own animated selectors rather than a
  * global override, which would also freeze antd's loading spinners. */
 @media (prefers-reduced-motion: reduce) {
-  .portfolio-row {
+  .portfolio-row,
+  .portfolio-empty-cta {
     transition: none;
   }
 }

--- a/src/pages/Portfolio/Portfolio.tsx
+++ b/src/pages/Portfolio/Portfolio.tsx
@@ -6,6 +6,7 @@ import {
   ArrowDown as ArrowDownIcon,
   ArrowUp as ArrowUpIcon,
   LoaderCircle as LoaderCircleIcon,
+  QrCode as QrCodeIcon,
   RotateCw as RotateCwIcon,
 } from 'lucide-react';
 import BigNumber from 'bignumber.js';
@@ -14,6 +15,7 @@ import { toast } from '../../lib/toast';
 import { useAppSelector } from '../../hooks';
 import { usePrivacyMode } from '../../contexts/PrivacyContext';
 import { sspConfig } from '@storage/ssp';
+import { isTestnetChain } from '@storage/blockchains';
 import { switchToChain } from '../../lib/chainSwitching';
 import {
   loadPortfolio,
@@ -42,6 +44,15 @@ function Portfolio() {
   const navigate = useNavigate();
   const { hidden, togglePrivacy } = usePrivacyMode();
   const { passwordBlob } = useAppSelector((state) => state.passwordBlob);
+  const { activeChain } = useAppSelector((state) => state.sspState);
+  // The active chain's current address — empty until the shell has derived it.
+  // Right after onboarding the app lands here BEFORE address generation
+  // finishes; the load effect below keys on this so the freshly paired chain
+  // moves out of "Not yet activated" the moment its address exists.
+  const activeAddress = useAppSelector((state) => {
+    const chainState = state[activeChain];
+    return chainState?.wallets?.[chainState.walletInUse]?.address ?? '';
+  });
   const { cryptoRates, fiatRates } = useAppSelector(
     (state) => state.fiatCryptoRates,
   );
@@ -122,7 +133,8 @@ function Portfolio() {
   useEffect(() => {
     let cancelled = false;
     void (async () => {
-      // Instant paint from cache, then a live concurrent refresh.
+      // Instant paint from cache, then a live concurrent refresh. Re-runs if
+      // the active chain's address materializes after mount (fresh pairing).
       await load(false);
       if (cancelled) return;
       await load(true);
@@ -130,7 +142,7 @@ function Portfolio() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [activeAddress]);
 
   // Re-value (not re-fetch) when rates change. Also re-fires once data first
   // loads, so rates that arrived while data was still null are applied. Once
@@ -182,11 +194,32 @@ function Portfolio() {
     () => (data ? data.chains.filter((c) => !c.needsActivation) : []),
     [data],
   );
+  // Testnets stay out of the activation list unless enabled in Settings.
+  // A testnet the user already synced is active and therefore always shown.
+  const showTestnets = Boolean(sspConfig().showTestnets);
   const inactiveChains = useMemo(
-    () => (data ? data.chains.filter((c) => c.needsActivation) : []),
-    [data],
+    () =>
+      data
+        ? data.chains.filter(
+            (c) =>
+              c.needsActivation && (showTestnets || !isTestnetChain(c.chain)),
+          )
+        : [],
+    [data, showTestnets],
   );
   const totalFiat = data?.totalFiat ?? 0;
+
+  // Truly-empty wallet: every active chain holds zero native AND zero tokens.
+  // Judged on crypto amounts, not fiat — fiat is also 0 while rates are still
+  // loading, and the CTA must not flash for funded wallets during that window.
+  const isEmptyWallet = useMemo(
+    () =>
+      activeChains.length > 0 &&
+      activeChains.every(
+        (c) => c.crypto.isZero() && c.tokens.every((tk) => tk.crypto.isZero()),
+      ),
+    [activeChains],
+  );
 
   const allocation = useMemo(() => {
     if (!data || totalFiat <= 0) return [];
@@ -280,6 +313,30 @@ function Portfolio() {
           )}
         </button>
       </div>
+
+      {isEmptyWallet && (
+        <button
+          type="button"
+          className="portfolio-empty-cta"
+          onClick={() => navigate('/home', { state: { openReceive: true } })}
+        >
+          <QrCodeIcon className="portfolio-empty-cta-icon" aria-hidden="true" />
+          <span className="portfolio-empty-cta-meta">
+            <span className="portfolio-empty-cta-title">
+              {t(
+                'home:portfolio.receive_first_title',
+                'Receive your first crypto',
+              )}
+            </span>
+            <span className="portfolio-empty-cta-sub">
+              {t(
+                'home:portfolio.receive_first_sub',
+                'Show your address to get started',
+              )}
+            </span>
+          </span>
+        </button>
+      )}
 
       {allocation.length > 0 && (
         <div className="portfolio-allocation">

--- a/src/pages/Restore/Restore.tsx
+++ b/src/pages/Restore/Restore.tsx
@@ -344,7 +344,7 @@ function Restore() {
     } else if (!Object.keys(wallets).length) {
       // Router state only — tells the shell's pairing screen to show the
       // "Import Wallet" wizard labels instead of the Create ones.
-      navigate('/home', { state: { imported: true } });
+      navigate('/portfolio', { state: { imported: true } });
     } else {
       navigate('/welcome');
     }

--- a/src/ssp.d.ts
+++ b/src/ssp.d.ts
@@ -74,6 +74,8 @@ declare module '@storage/ssp' {
     fiatCurrency: keyof currency;
     fiatSymbol: string;
     relay: string;
+    // testnet networks stay out of chain lists unless enabled
+    showTestnets: boolean;
     enterpriseNotification?: enterpriseNotificationConfig;
   }
 
@@ -87,6 +89,7 @@ declare module '@storage/ssp' {
   let updateUserPreferences: (prefs: {
     relay?: string;
     fiatCurrency?: keyof currency;
+    showTestnets?: boolean;
   }) => Promise<void>;
   let getEnterpriseNotificationConfig: () => enterpriseNotificationConfig | null;
   let updateEnterpriseNotificationConfig: (

--- a/src/storage/blockchains.ts
+++ b/src/storage/blockchains.ts
@@ -572,3 +572,9 @@ export const blockchains = {
   amoy,
   solDevnet,
 };
+
+// SLIP-44 coin type 1 is the universal testnet marker — every testnet config
+// in this file carries it (btcTestnet, btcSignet, fluxTestnet, sepolia, amoy,
+// solDevnet) and no mainnet ever does.
+export const isTestnetChain = (chain: keyof typeof blockchains): boolean =>
+  blockchains[chain].slip === 1;

--- a/src/storage/navPrefs.ts
+++ b/src/storage/navPrefs.ts
@@ -6,7 +6,7 @@ import localForage from 'localforage';
  * Invariant 6 (storage is append-only): these live in a NEW localForage key,
  * completely separate from `sspConfig`, wallet state, `themeMode`, etc. Nothing
  * here is required for correctness — a missing/corrupt value falls back to the
- * safe default (Home). Losing it never affects funds, keys or pairing.
+ * safe default (Portfolio). Losing it never affects funds, keys or pairing.
  *
  * Note: the Menu (settings) tab is a single scrolling page, so only the last
  * TAB is remembered — there is no per-section position to restore.
@@ -42,7 +42,9 @@ export async function getNavPrefs(): Promise<NavPrefs> {
   } catch (error) {
     console.log('[navPrefs] read failed', error);
   }
-  return { lastTab: 'home' };
+  // Portfolio is the chain-neutral landing view — the default until the user
+  // has actually left off somewhere else.
+  return { lastTab: 'portfolio' };
 }
 
 export async function getLastTab(): Promise<WalletTab> {

--- a/src/storage/ssp.ts
+++ b/src/storage/ssp.ts
@@ -35,6 +35,9 @@ interface config {
   fiatCurrency?: keyof currency; // user adjustable
   maxTxFeeUSD?: number;
   fiatSymbol?: string;
+  // user adjustable — testnet networks stay out of chain lists unless enabled
+  // (absent = false)
+  showTestnets?: boolean;
   tutorial: tutorialConfig;
   enterpriseNotification?: enterpriseNotificationConfig;
 }
@@ -72,6 +75,7 @@ export function sspConfig(): config {
     relay: storedLocalForgeSSPConfig?.relay ?? ssp.relay,
     fiatCurrency: storedLocalForgeSSPConfig?.fiatCurrency ?? ssp.fiatCurrency,
     maxTxFeeUSD: storedLocalForgeSSPConfig?.maxTxFeeUSD ?? ssp.maxTxFeeUSD,
+    showTestnets: storedLocalForgeSSPConfig?.showTestnets ?? false,
     tutorial: storedLocalForgeSSPConfig?.tutorial ?? ssp.tutorial,
     fiatSymbol: getFiatSymbol(
       storedLocalForgeSSPConfig?.fiatCurrency ?? ssp.fiatCurrency ?? 'USD',
@@ -106,6 +110,7 @@ async function readStoredConfig(): Promise<Partial<config>> {
 export async function updateUserPreferences(prefs: {
   relay?: string;
   fiatCurrency?: keyof currency;
+  showTestnets?: boolean;
 }) {
   const next: Partial<config> = { ...(await readStoredConfig()) };
 
@@ -121,6 +126,14 @@ export async function updateUserPreferences(prefs: {
       delete next.fiatCurrency;
     } else {
       next.fiatCurrency = prefs.fiatCurrency;
+    }
+  }
+  if (prefs.showTestnets !== undefined) {
+    // shipped default is "hidden" — store the key only when enabled
+    if (!prefs.showTestnets) {
+      delete next.showTestnets;
+    } else {
+      next.showTestnets = true;
     }
   }
 

--- a/src/translations/resources/en/home.json
+++ b/src/translations/resources/en/home.json
@@ -191,6 +191,7 @@
     "theme_system": "System",
     "theme_light": "Light",
     "theme_dark": "Dark",
+    "show_testnets": "Show testnet networks",
     "use_system_language": "Use System Language",
     "public_nonces_sync": "Public Nonces",
     "sync_public_nonces": "Sync Public Nonces",
@@ -1017,7 +1018,9 @@
     "tap_to_activate": "Tap to activate",
     "activating": "Activating…",
     "refresh_failed": "Couldn't refresh — showing the last saved values.",
-    "incl_tokens": "incl. {{amount}} tokens"
+    "incl_tokens": "incl. {{amount}} tokens",
+    "receive_first_title": "Receive your first crypto",
+    "receive_first_sub": "Show your address to get started"
   },
   "activityFeed": {
     "all": "All",


### PR DESCRIPTION
## Summary

- **Portfolio is the default landing tab** — navPrefs default, login fallback and post-restore navigation now point at the chain-neutral Portfolio view; returning users still resume the tab they last left off on.
- **Zero-balance receive CTA** — brand-new wallets see a "Receive your first crypto" tile under the $0.00 total that opens the Receive sheet directly. Shown only while every active chain holds zero native + zero tokens (judged on crypto amounts so it never flashes while rates load).
- **Testnets behind a settings flag (default off)** — new "Show testnet networks" toggle in Menu → Preferences. Off by default: testnets are hidden from the Portfolio activation list, the wallet switcher networks section and the pairing chips. The currently active chain and already-synced testnets always stay visible.
- **Race fix** — portfolio discovery merges the in-memory redux address map and reloads when the active address materializes, so a freshly paired identity chain is never misread as "not yet activated" when landing directly on Portfolio.

## Verification

- type-check / lint / build green, 713/713 unit tests pass
- Playwright harness against the built extension (popup 420×800 + panel 1280×800, dark + light): lands on Portfolio after onboarding, CTA renders and opens Receive, testnets absent from portfolio + switcher lists
- Tutorial completes all 21 steps in both modes from the new landing (it self-navigates to Home on start)
- Upgrade-in-place gate passes v1.40.0 → v2.0.0 (script now hops to the Home tab before reading the address)